### PR TITLE
Generalize to non-scalar matrices by altering drop criterion

### DIFF
--- a/src/sparse_vector_accumulator.jl
+++ b/src/sparse_vector_accumulator.jl
@@ -1,5 +1,5 @@
 import Base: setindex!, empty!, Vector
-import LinearAlgebra: axpy!
+import LinearAlgebra: axpy!, norm
 
 """
 `SparseVectorAccumulator` accumulates the sparse vector
@@ -108,7 +108,7 @@ function append_col!(A::SparseMatrixCSC, y::SparseVectorAccumulator, j::Integer,
         row = y.nzind[idx]
         value = y.nzval[row]
 
-        if abs(value) ≥ drop || row == j
+        if (drop == 0 || norm(value) ≥ drop) || row == j
             total += 1
             y.nzind[total] = row
         end


### PR DESCRIPTION
Two small improvements:
- Short-circuit drop-tol check when drop == 0
- Use norm (Frobenius/2-norm by default) instead of abs to allow non-scalar element types.

Here's an example of how this can be used with StaticArrays to produce block-preconditioners:
```julia
using LinearAlgebra, StaticArrays, SparseArrays

# Make block version of identity matrix
E = SMatrix{2,2}(1, 0, 0, 1.0)
Z = SMatrix{2,2}(0, 0, 0, 0.0)
ii = collect(1:2)
A = sparse(ii, ii, [E, E])                     # Identity matrix with blocks
b = [SVector(1., 2.), SVector(3., 4.)] # Just 1, 2, 3, 4 represented as [[1, 2], [3, 4]]
A\b
##
using IncompleteLU
fact = ilu(A, τ = 0.)
##
fact = ilu(A, τ = 0.1)
```
The tests were not affected by my changes and there shouldn't be any difference for the scalar case unless a type has `norm(R)` different from `sqrt(abs(R))`.