### PR TITLE
Add eltype definition for ILUFactorization

### DIFF
--- a/src/IncompleteLU.jl
+++ b/src/IncompleteLU.jl
@@ -7,6 +7,7 @@ struct ILUFactorization{Tv,Ti}
     L::SparseMatrixCSC{Tv,Ti}
     U::SparseMatrixCSC{Tv,Ti}
 end
+Base.eltype(::IncompleteLU.ILUFactorization{Tv,Ti}) where {Tv,Ti} = Tv
 
 include("sorted_set.jl")
 include("linked_list.jl")


### PR DESCRIPTION
Honestly this shouldn't be required, but for some reason Krylov.jl wants to check the eltype of a preconditioner. I'm telling them not to ask for potentially undefined quantities here: https://github.com/JuliaSmoothOptimizers/Krylov.jl/pull/477, but in the meantime this is required for compatibility.